### PR TITLE
allow for recent versions of bindeps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
 julia = "^1.0.0"
-BinDeps = "^0.8.10"
+BinDeps = "0.8.10, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
As mentioned in #13 this package seems to unnecessarily hold back other packages from upgrading with this compat restriction.